### PR TITLE
Assign front-matter category for news-filtering in conf.builderscon.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,8 @@ twitter_username: builderscon
 github_username:  builderscon
 fb_app_id: 1537973726511652
 fb_page_id: 1233910219973110
-
 markdown: kramdown
+permalink: /:year/:month/:day/:title.html
 
 authors:
   lestrrat:

--- a/_posts/2015-08-18-mission-statement.md
+++ b/_posts/2015-08-18-mission-statement.md
@@ -2,9 +2,12 @@
 layout: post
 title:  "Mission Statement"
 date:   2015-08-18 13:06:50 +0900
-categories: builderscon
+category: builderscon
+permalink: /builderscon/:year/:month/:day/:title.html
 author: lestrrat
 ---
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
 
 builderscon (Builders Conference) is to be conference for the modern world builders -- programmers, mechanical engineers, future technology architects -- the architects that build our services, our gadgets, our infrastructure, our future.
 

--- a/_posts/2016-02-14-where-builderscon-is-going.md
+++ b/_posts/2016-02-14-where-builderscon-is-going.md
@@ -2,9 +2,12 @@
 layout: post
 title:  "Where builderscon Is Going"
 date:   2016-02-14 13:06:50 +0900
-categories: builderscon jp
+category: builderscon jp
+permalink: /builderscon/jp/:year/:month/:day/:title.html
 author: lestrrat
 ---
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
 
 いよいよ[今週builderscon開催に向けて説明会的なことをする](http://eventdots.jp/event/579495)予定なのですが、このbuilderscon説明する際、buildersconと[YAPC::Asia Tokyo](http://yapcasia.org/2015/)の関係性を気にされる方がたくさんいます。これは当然で、buildersconの首謀者である[lestrratこと牧](https://twitter.com/lestrrat)はYAPC::Asia Tokyoスタッフから始めたのち主催になり、2015年までの合計10年間YAPC::Asia Tokyoに関わってきたからです。
 

--- a/_posts/2016-05-30-join-slack.md
+++ b/_posts/2016-05-30-join-slack.md
@@ -2,9 +2,12 @@
 layout: post
 title:  "Join our Slack Team!"
 date:   2016-05-30 15:00:00 +0900
-categories: builderscon
+categories: builderscon/tokyo/2016
+permalink: /builderscon/:year/:month/:day/:title.html
 author: lestrrat
 ---
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
 
 If you are interested in builderscon, [please join our Slack team](https://slack-invite-dot-builderscon-1248.appspot.com/)!
 

--- a/_posts/2016-06-06-annoucing-builderscon-1.md
+++ b/_posts/2016-06-06-annoucing-builderscon-1.md
@@ -2,9 +2,12 @@
 layout: post
 title:  "Announcing builderscon #1"
 date:   2016-06-06 09:30:00 +0900
-categories: builderscon
+category: builderscon/tokyo/2016
+permalink: /builderscon/:year/:month/:day/:title.html
 author: lestrrat
 ---
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
 
 We are very happy to announce that we are currently working to bring you the first builderscon on *Dec 3, 2016*. Details are still in the works, but we are going to try our best to bring you the best, most interesting talks that we can find.
 

--- a/_posts/2016-06-06-call-for-sponsors.md
+++ b/_posts/2016-06-06-call-for-sponsors.md
@@ -2,9 +2,12 @@
 layout: post
 title:  "Call for sponsorship for builderscon #1"
 date:   2016-06-06 10:00:00 +0900
-categories: builderscon
+category: builderscon/tokyo/2016
+permalink: /builderscon/:year/:month/:day/:title.html
 author: lestrrat
 ---
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
 
 We have started looking for sponsors for the [first builderscon](http://blog.builderscon.io/builderscon/2016/06/06/annoucing-builderscon-1.html) conference.
 

--- a/_posts/2016-06-27-session-timer.md
+++ b/_posts/2016-06-27-session-timer.md
@@ -2,10 +2,13 @@
 layout: post
 title:  "Releasing Our Session Timers"
 date:   2016-06-27 10:30:00 +0900
-categories: builderscon
+category: builderscon
+permalink: /builderscon/:year/:month/:day/:title.html
 author: lestrrat
 ---
-
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
+category
 （日本語は英語の後にあります）
 
 Time keeping during a session is one of the main responsibilities of a conference staff. It's a simple enough job, but there are subtle things that must be taught to new staff members each time we hold a conference.

--- a/_posts/2016-07-04-session-timer-android.md
+++ b/_posts/2016-07-04-session-timer-android.md
@@ -2,9 +2,12 @@
 layout: post
 title:  "builderscon Session Timer for Android"
 date:   2016-07-04 10:30:00 +0900
-categories: builderscon
+category: builderscon
+permalink: /builderscon/:year/:month/:day/:title.html
 author: lestrrat
 ---
+<!-- front-matter category is used for news filtering in conf.builderscon.io, so if post is conference news, match it with conference slug (e.g.)builderscon/tokyo/2016 -->
+<!-- front-matter permalink in each post is to keep backward compat, not needed for new posts -->
 
 （日本語は英語の後にあります）
 


### PR DESCRIPTION
いずれcategoryのつけ方の方針は変わるかもしれませんが、とりあえず
- categoryはひとつだけ
- どれか一つのカンファレンス向けのニュースの場合、カンファレンスのslugと一致させる -> conf.builderscon.ioでフィルタリングに使う

という感じでどうでしょう？

あと、補足情報
- _posts以下の.mdファイル
  - 多分新しい記事を書く人は過去の記事をコピペしてからいじると思うので、&lt;&#33;-- --&gt;で説明用のコメントを足しました
  - あと、カテゴリ一つだけなのを分かりやすくするためcategories -> categoryに変更
  - postのpermalink指定で過去postのpermalinkが変わらないことは確認済み
- _config.yml
  - またいずれカテゴリの使い方変わるかもしれないので、影響を受けないように新しいpostはcategoryをpermalinkに含めない
